### PR TITLE
optimize replacing LRU cache entries

### DIFF
--- a/cache/lru.go
+++ b/cache/lru.go
@@ -25,9 +25,11 @@ func (lru *LRU[K, V]) Insert(key K, value V) (previous V, replaced bool) {
 	e, ok := lru.index[key]
 	if ok {
 		previous, replaced = e.Value.value, true
-		lru.queue.Remove(e)
+		e.Value.value = value
+		lru.queue.MoveToFront(e)
+	} else {
+		lru.index[key] = lru.queue.PushFront(entry[K, V]{key: key, value: value})
 	}
-	lru.index[key] = lru.queue.PushFront(entry[K, V]{key: key, value: value})
 	return previous, replaced
 }
 


### PR DESCRIPTION
I noticed this improvement while reading through the code, when replacing an entry which already exists in the cache, we don't need to remove and insert and can simply modify the value and move the element to the front of the list. This removes the memory allocation of the new element, and garbage collection of the one that was removed, and removes the access to the map of entries.