### PR TITLE
Add heap, array, and queue generic container types

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: "1.20"
     - name: Test
       run: |
         go test -v -race ./...

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: "1.20"
+        go-version: "1.22"
     - name: Test
       run: |
         go test -v -race ./...

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v5
       with:
         go-version: "1.22"
     - name: Test

--- a/container/array/array.go
+++ b/container/array/array.go
@@ -55,16 +55,16 @@ func (a *Array[T]) NextWithPool(pool *Pool[T]) (ptr *T, index int) {
 	return
 }
 
-// Pop removes the last item from the array.
-func (a *Array[T]) Pop() {
-	a.PopWithPool(nil)
+// Pop removes the last item from the array and returns the value.
+func (a *Array[T]) Pop() T {
+	return a.PopWithPool(nil)
 }
 
 // PopWithPool removes the last item from the array. If the popped value is the
 // last in a block, the block will be removed and returned to the pool.
-func (a *Array[T]) PopWithPool(pool *Pool[T]) {
+func (a *Array[T]) PopWithPool(pool *Pool[T]) T {
 	i := len(a.blocks) - 1
-	a.blocks[i].pop()
+	v := a.blocks[i].pop()
 
 	if a.blocks[i].len() == 0 {
 		free := a.blocks[i].reset()
@@ -79,6 +79,7 @@ func (a *Array[T]) PopWithPool(pool *Pool[T]) {
 			a.blocks = blocks
 		}
 	}
+	return v
 }
 
 // ShiftBlocks removes `n` number of blocks (`n * BlockLen[T]()` entries) from

--- a/container/array/array.go
+++ b/container/array/array.go
@@ -131,6 +131,9 @@ func (a *Array[T]) Get(i int) T {
 // the array. Like a Go slice this results in a panic if the value is outside
 // the array bounds.
 func (a *Array[T]) Ptr(i int) *T {
+	if i < 0 {
+		panic(fmt.Sprintf("runtime error: index out of range [%d]", i))
+	}
 	if n := a.Len(); i >= n {
 		panic(fmt.Sprintf("runtime error: index out of range [%d] with length %d", i, n))
 	}

--- a/container/array/array.go
+++ b/container/array/array.go
@@ -1,5 +1,7 @@
 package array
 
+import "fmt"
+
 // Array works similarly to a Go slice, however the allocation is performed
 // in blocks rather than a single sequential allocation. This means that appends
 // do not need to fully copy prior entries during reallocation, and entries have
@@ -28,7 +30,7 @@ func (a *Array[T]) PushPtr(v *T) {
 
 // PushPtrWithPool appends a value into the array by copying a value from an
 // existing memory address. If a new block needs to be allocated, it will
-// attempt reusing an existing one provided by the pool.
+// attempt to reuse an existing one provided by the pool.
 func (a *Array[T]) PushPtrWithPool(v *T, pool *Pool[T]) {
 	p, _ := a.NextWithPool(pool)
 	*p = *v
@@ -129,6 +131,9 @@ func (a *Array[T]) Get(i int) T {
 // the array. Like a Go slice this results in a panic if the value is outside
 // the array bounds.
 func (a *Array[T]) Ptr(i int) *T {
+	if n := a.Len(); i >= n {
+		panic(fmt.Sprintf("runtime error: index out of range [%d] with length %d", i, n))
+	}
 	size := BlockLen[T]()
 	b, o := i/size, i%size
 	return a.blocks[b].at(o)
@@ -143,12 +148,12 @@ func (a *Array[T]) Len() int {
 	return n
 }
 
-// Cap returns the current capacity of the array without furthur reallocation.
+// Cap returns the current capacity of the array without further reallocation.
 func (a *Array[T]) Cap() int {
 	return len(a.blocks) * BlockLen[T]()
 }
 
-// Empty tests if the array contains no entries.
+// Empty reports whether if the array contains no entries.
 func (a *Array[T]) Empty() bool {
 	return len(a.blocks) == 0
 }

--- a/container/array/array.go
+++ b/container/array/array.go
@@ -147,6 +147,11 @@ func (a *Array[T]) Cap() int {
 	return len(a.blocks) * BlockLen[T]()
 }
 
+// Empty tests if the array contains no entries.
+func (a *Array[T]) Empty() bool {
+	return len(a.blocks) == 0
+}
+
 // Reset removes all entries and releases all blocks into the pool if provided.
 func (a *Array[T]) Reset(pool *Pool[T]) {
 	if pool != nil {

--- a/container/array/array.go
+++ b/container/array/array.go
@@ -1,0 +1,107 @@
+package array
+
+// Array works similarly to a Go slice, however the allocation is performed
+// in blocks rather than a single sequential allocation. This means that appends
+// do not need to fully copy prior entries during reallocation, and entries have
+// pointer stability throughout their lifetime.
+type Array[T any] struct {
+	blocks []block[T]
+}
+
+// Push appends a value into the array.
+func (a *Array[T]) Push(v T) {
+	p, _ := a.Next()
+	*p = v
+}
+
+// PushPtr appends a value into the array by copying a value from an existing
+// memory address.
+func (a *Array[T]) PushPtr(v *T) {
+	p, _ := a.Next()
+	*p = *v
+}
+
+// Next obtains a pointer to the next slot, allocating new space if needed.
+// The returned pointer will be zero-initialized.
+func (a *Array[T]) Next() (ptr *T, index int) {
+	return a.NextWithPool(nil)
+}
+
+// NextWithPool obtains a pointer to the next slot, allocating new space from the
+// optionally provided pool if needed. The returned pointer will be zero-initialized.
+func (a *Array[T]) NextWithPool(pool *Pool[T]) (ptr *T, index int) {
+	i := len(a.blocks) - 1
+	if i >= 0 && a.blocks[i].available() {
+		ptr, index = a.blocks[i].next()
+	} else {
+		a.blocks = append(a.blocks, block[T]{slots: pool.get(), count: 1})
+		i++
+		ptr = &a.blocks[i].slots[index]
+	}
+	index += i * BlockLen[T]()
+	return
+}
+
+// Pop removes the last item from the array.
+func (a *Array[T]) Pop() {
+	a.PopWithPool(nil)
+}
+
+func (a *Array[T]) PopWithPool(pool *Pool[T]) {
+	i := len(a.blocks) - 1
+	a.blocks[i].pop()
+
+	if a.blocks[i].len() == 0 {
+		free := a.blocks[i].reset()
+		if pool != nil {
+			pool.put(free)
+		}
+		a.blocks = a.blocks[:i]
+
+		if len(a.blocks) < cap(a.blocks)/4 {
+			blocks := make([]block[T], len(a.blocks), cap(a.blocks)/2)
+			copy(blocks, a.blocks)
+			a.blocks = blocks
+		}
+	}
+}
+
+// Get obtains the value of an entry at a specific offset. Like a Go slice
+// this results in a panic if the value is outside the array bounds.
+func (a *Array[T]) Get(i int) T {
+	return *a.Ptr(i)
+}
+
+// Ptr obtains the pointer to a value for an entry at a specific offset. The
+// returned pointer is guaranteed not to change until the index is popped from
+// the array. Like a Go slice this results in a panic if the value is outside
+// the array bounds.
+func (a *Array[T]) Ptr(i int) *T {
+	size := BlockLen[T]()
+	b, o := i/size, i%size
+	return a.blocks[b].at(o)
+}
+
+// Len returns the number of entries added to the array.
+func (a *Array[T]) Len() int {
+	n := len(a.blocks)
+	if n > 0 {
+		n = (BlockLen[T]() * (n - 1)) + a.blocks[n-1].len()
+	}
+	return n
+}
+
+// Cap returns the current capacity of the array without furthur reallocation.
+func (a *Array[T]) Cap() int {
+	return len(a.blocks) * BlockLen[T]()
+}
+
+// Reset removes all entries and releases all blocks into the pool if provided.
+func (a *Array[T]) Reset(pool *Pool[T]) {
+	if pool != nil {
+		for _, b := range a.blocks {
+			pool.put(b.slots)
+		}
+	}
+	*a = Array[T]{}
+}

--- a/container/array/array.go
+++ b/container/array/array.go
@@ -10,14 +10,27 @@ type Array[T any] struct {
 
 // Push appends a value into the array.
 func (a *Array[T]) Push(v T) {
-	p, _ := a.Next()
+	a.PushWithPool(v, nil)
+}
+
+// PushWithPool appends a value into the array, pulling a block from the
+// provided pool when needed.
+func (a *Array[T]) PushWithPool(v T, pool *Pool[T]) {
+	p, _ := a.NextWithPool(pool)
 	*p = v
 }
 
 // PushPtr appends a value into the array by copying a value from an existing
 // memory address.
 func (a *Array[T]) PushPtr(v *T) {
-	p, _ := a.Next()
+	a.PushPtrWithPool(v, nil)
+}
+
+// PushPtrWithPool appends a value into the array by copying a value from an
+// existing memory address. If a new block needs to be allocated, it will
+// attempt reusing an existing one provided by the pool.
+func (a *Array[T]) PushPtrWithPool(v *T, pool *Pool[T]) {
+	p, _ := a.NextWithPool(pool)
 	*p = *v
 }
 
@@ -47,6 +60,8 @@ func (a *Array[T]) Pop() {
 	a.PopWithPool(nil)
 }
 
+// PopWithPool removes the last item from the array. If the popped value is the
+// last in a block, the block will be removed and returned to the pool.
 func (a *Array[T]) PopWithPool(pool *Pool[T]) {
 	i := len(a.blocks) - 1
 	a.blocks[i].pop()
@@ -64,6 +79,42 @@ func (a *Array[T]) PopWithPool(pool *Pool[T]) {
 			a.blocks = blocks
 		}
 	}
+}
+
+// ShiftBlocks removes `n` number of blocks (`n * BlockLen[T]()` entries) from
+// the beginning of the array, shifting the remaining blocks down. If `n` exceeds
+// the number of blocks in the array, none are removed and false is returned.
+func (a *Array[T]) ShiftBlocks(n int) bool {
+	return a.ShiftBlocksWithPool(n, nil)
+}
+
+// ShiftBlocksWithPool removes whole blocks from the array like ShiftBlocks. If
+// a pool is provided, the removed blocks will be given back to it.
+//
+// When using a pool, it is important to ensure any entries that contain heap
+// allocations are cleared. For example, the entire blocks may be cleared at once:
+//
+//	type Item { values []int }
+//	func removeBlocks(items array.Pool[Item], blocks int, pool *array.Pool[Item]) {
+//		n := array.BlockLen[Item] * blocks
+//		for i := 0; i < n; i++ {
+//			items.Ptr(i).values = nil
+//		}
+//		items.ShiftBlocksWithPool(blocks, &pool)
+//	}
+func (a *Array[T]) ShiftBlocksWithPool(n int, pool *Pool[T]) bool {
+	if n >= len(a.blocks) {
+		return false
+	}
+
+	if pool != nil {
+		for i := 0; i < n; i++ {
+			pool.put(a.blocks[i].slots)
+		}
+	}
+	a.blocks = a.blocks[n:]
+
+	return true
 }
 
 // Get obtains the value of an entry at a specific offset. Like a Go slice

--- a/container/array/array_test.go
+++ b/container/array/array_test.go
@@ -179,3 +179,34 @@ func TestEmpty(t *testing.T) {
 		t.Error("should be empty")
 	}
 }
+
+func TestPanicEmpty(t *testing.T) {
+	defer func() {
+		expect := "runtime error: index out of range [2] with length 0"
+		actual := recover()
+		if expect != actual {
+			t.Errorf("incorrect panic: got=%v, expect=%v", actual, expect)
+		}
+	}()
+
+	var a Array[int]
+	invalid := a.Get(2)
+	t.Errorf("should not be reachable: got=%d", invalid)
+}
+
+func TestPanicOver(t *testing.T) {
+	defer func() {
+		expect := "runtime error: index out of range [2] with length 2"
+		actual := recover()
+		if expect != actual {
+			t.Errorf("incorrect panic: got=%v, expect=%v", actual, expect)
+		}
+	}()
+
+	var a Array[int]
+	a.Push(123)
+	a.Push(456)
+
+	invalid := a.Get(2)
+	t.Errorf("should not be reachable: got=%d", invalid)
+}

--- a/container/array/array_test.go
+++ b/container/array/array_test.go
@@ -153,3 +153,26 @@ func TestPool(t *testing.T) {
 
 	t.Error("no pointers were reused")
 }
+
+func TestEmpty(t *testing.T) {
+	var a Array[int]
+
+	if !a.Empty() {
+		t.Error("should be empty")
+	}
+
+	for i := 0; i < testLen; i++ {
+		a.Push(i)
+		if a.Empty() {
+			t.Error("should not be empty")
+		}
+	}
+
+	for i := 0; i < testLen; i++ {
+		a.Pop()
+	}
+
+	if !a.Empty() {
+		t.Error("should be empty")
+	}
+}

--- a/container/array/array_test.go
+++ b/container/array/array_test.go
@@ -28,7 +28,10 @@ func TestCapacity(t *testing.T) {
 	}
 
 	for i := 0; i < testLen; i++ {
-		a.Pop()
+		expect := testLen - i - 1
+		if v := a.Pop(); v != expect {
+			t.Errorf("incorrect popped value: got=%d, expect=%d", v, expect)
+		}
 	}
 
 	if a.Len() != 0 {

--- a/container/array/array_test.go
+++ b/container/array/array_test.go
@@ -210,3 +210,19 @@ func TestPanicOver(t *testing.T) {
 	invalid := a.Get(2)
 	t.Errorf("should not be reachable: got=%d", invalid)
 }
+
+func TestPanicNegative(t *testing.T) {
+	defer func() {
+		expect := "runtime error: index out of range [-1]"
+		actual := recover()
+		if expect != actual {
+			t.Errorf("incorrect panic: got=%v, expect=%v", actual, expect)
+		}
+	}()
+
+	var a Array[int]
+	a.Push(123)
+
+	invalid := a.Get(-1)
+	t.Errorf("should not be reachable: got=%d", invalid)
+}

--- a/container/array/array_test.go
+++ b/container/array/array_test.go
@@ -1,0 +1,155 @@
+package array
+
+import (
+	"testing"
+	"unsafe"
+)
+
+const testLen = 100000
+
+func TestCapacity(t *testing.T) {
+	var a Array[int]
+	for i := 0; i < testLen; i++ {
+		a.Push(i)
+	}
+
+	if a.Len() != testLen {
+		t.Errorf("incorrect length: got=%d, expect=%d", a.Len(), testLen)
+	}
+
+	if expectCap := BlockCap[int](testLen); a.Cap() != expectCap {
+		t.Errorf("incorrect capacity: got=%d, expect=%d", a.Cap(), expectCap)
+	}
+
+	for i := 0; i < testLen; i++ {
+		if a.Get(i) != i {
+			t.Errorf("incorrect value at %d: got=%d, expect=%d", i, a.Get(i), i)
+		}
+	}
+
+	for i := 0; i < testLen; i++ {
+		a.Pop()
+	}
+
+	if a.Len() != 0 {
+		t.Errorf("incorrect length: got=%d, expect=0", a.Len())
+	}
+	if a.Cap() != 0 {
+		t.Errorf("incorrect capacity: got=%d, expect=%d", a.Cap(), 0)
+	}
+
+	a.Push(testLen + 1)
+
+	if a.Len() != 1 {
+		t.Errorf("incorrect length: got=%d, expect=1", a.Len())
+	}
+	if expect := BlockLen[int](); a.Cap() != expect {
+		t.Errorf("incorrect capacity: got=%d, expect=%d", a.Cap(), expect)
+	}
+}
+
+func TestPointerStability(t *testing.T) {
+	var a Array[int]
+	var ptrs [100]*int
+
+	for i := range ptrs {
+		a.Push(i)
+		if a.Len() != i+1 {
+			t.Errorf("incorrect length: got=%d, expect=%d", a.Len(), i+1)
+		}
+		if a.Get(i) != i {
+			t.Errorf("incorrect value at %d: got=%d, expect=%d", i, a.Get(i), i)
+		}
+		ptrs[i] = a.Ptr(i)
+	}
+
+	for i := len(ptrs); i < 100000; i++ {
+		a.Push(i)
+		if a.Len() != i+1 {
+			t.Errorf("incorrect length: got=%d, expect=%d", a.Len(), i+1)
+		}
+		if a.Get(i) != i {
+			t.Errorf("incorrect value at %d: got=%d, expect=%d", i, a.Get(i), i)
+		}
+	}
+
+	for i, ptr := range ptrs {
+		if ptr != a.Ptr(i) {
+			t.Errorf("incorrect ptr at %d: got=%p, expect=%p", i, a.Ptr(i), ptr)
+		}
+		if *ptr != i {
+			t.Errorf("incorrect value at for pointer %d: got=%d, expect=%d", i, *ptr, i)
+		}
+	}
+
+	for a.Len() > len(ptrs) {
+		a.Pop()
+	}
+
+	for i, ptr := range ptrs {
+		if ptr != a.Ptr(i) {
+			t.Errorf("incorrect ptr at %d: got=%p, expect=%p", i, a.Ptr(i), ptr)
+		}
+		if *ptr != i {
+			t.Errorf("incorrect value at for pointer %d: got=%d, expect=%d", i, *ptr, i)
+		}
+	}
+}
+
+func TestPushPtr(t *testing.T) {
+	var a Array[int]
+	var val int
+
+	for i := 0; i < testLen; i++ {
+		val = i * 3
+		a.PushPtr(&val)
+	}
+
+	for i := 0; i < testLen; i++ {
+		expect := i * 3
+		actual := a.Get(i)
+
+		if expect != actual {
+			t.Errorf("incorrect value at %d: got=%d, expect=%d", i, actual, expect)
+		}
+	}
+}
+
+func TestPool(t *testing.T) {
+	var pool Pool[int]
+	var a Array[int]
+
+	for i := 0; i < testLen; i++ {
+		ptr, _ := a.NextWithPool(&pool)
+		*ptr = i
+	}
+
+	addrs := map[uintptr]struct{}{}
+	for i := range a.blocks {
+		addr := uintptr(unsafe.Pointer(&a.blocks[i].slots[0]))
+		addrs[addr] = struct{}{}
+	}
+
+	for i := 0; i < testLen/2; i++ {
+		a.PopWithPool(&pool)
+	}
+
+	for i := 0; i < testLen/2; i++ {
+		ptr, _ := a.NextWithPool(&pool)
+		if *ptr != 0 {
+			t.Fatalf("incorrect zero value at %d: got=%d, expect=0", i, *ptr)
+		}
+		*ptr = i
+	}
+
+	// We can't test if all pointers are reused, because sometimes the pool does
+	// not keep the value.
+	for i := range a.blocks {
+		addr := uintptr(unsafe.Pointer(&a.blocks[i].slots[0]))
+		if _, ok := addrs[addr]; ok {
+			return
+		}
+	}
+
+	t.Error("no pointers were reused")
+}

--- a/container/array/block.go
+++ b/container/array/block.go
@@ -59,9 +59,11 @@ func (b *block[T]) available() bool { return b.count < cap(b.slots) }
 // pop zeroes out the last entries and decrements the count. We zero the entry
 // so that it allows any pointers to be nil'ed and availble for GC. This also
 // ensures that Next always returns zeroed memory.
-func (b *block[T]) pop() {
+func (b *block[T]) pop() T {
 	i := b.count - 1
 	b.count = i
-	var zero T
-	b.slots[i] = zero
+
+	var v T
+	v, b.slots[i] = b.slots[i], v
+	return v
 }

--- a/container/array/block.go
+++ b/container/array/block.go
@@ -1,0 +1,67 @@
+package array
+
+import "unsafe"
+
+// BlockSize is the memory allocation size in bytes for each block slot. This
+// is converted into a slice capacity using the BlockLen function.
+const BlockSize = 64 * 1024
+
+// BlockLen calculates the entry count required to fill a slice of BlockSize
+// bytes. Because the type is generic, we can't use const. However, as of go
+// 1.20, the compiler will turn this into a constant expression. For example,
+// BlockLen[int]() turns into 8192. On x86_64, this can be seen in Next:
+//
+//	CALL    runtime.makeslice(SB)
+//	MOVL    $8192, CX
+//	MOVL    $8192, DI
+//
+// ... and fast integer division/modulus in Ptr:
+//
+//	MOVQ    BX, SI
+//	SARQ    $13, BX
+//	ANDQ    $-8192, SI
+func BlockLen[T any]() int {
+	var v T
+	return BlockSize / int(unsafe.Sizeof(v))
+}
+
+// BlockCap rounds n up to the nearest BlockLen.
+func BlockCap[T any](n int) int {
+	return (n + BlockLen[T]() - 1) / BlockLen[T]() * BlockLen[T]()
+}
+
+type block[T any] struct {
+	slots []T
+	count int
+}
+
+// reset clears the block and returns the slot slice for possible reuse.
+func (b *block[T]) reset() []T {
+	slots := b.slots
+	b.slots = nil
+	b.count = 0
+	return slots
+}
+
+// next increments the count and returns a pointer to the new location. This
+// does NOT validate that count is availble in the underlying slice.
+func (b *block[T]) next() (p *T, index int) {
+	index = b.count
+	p = &b.slots[index]
+	b.count = index + 1
+	return
+}
+
+func (b *block[T]) at(i int) *T     { return &b.slots[i] }
+func (b *block[T]) len() int        { return b.count }
+func (b *block[T]) available() bool { return b.count < cap(b.slots) }
+
+// pop zeroes out the last entries and decrements the count. We zero the entry
+// so that it allows any pointers to be nil'ed and availble for GC. This also
+// ensures that Next always returns zeroed memory.
+func (b *block[T]) pop() {
+	i := b.count - 1
+	b.count = i
+	var zero T
+	b.slots[i] = zero
+}

--- a/container/array/pool.go
+++ b/container/array/pool.go
@@ -1,0 +1,26 @@
+package array
+
+import (
+	"sync"
+	"unsafe"
+)
+
+// Pool is a memory pool for reusing block allocations. The pool can be
+// shared across any BucketArray of the same type.
+type Pool[T any] struct{ p sync.Pool }
+
+// get returns a slice out of the pool. If the pool is nil or empty, a new
+// slice is allocated.
+func (p *Pool[T]) get() []T {
+	if p != nil {
+		if b, ok := p.p.Get().(*T); ok {
+			return unsafe.Slice(b, BlockLen[T]())
+		}
+	}
+	return make([]T, BlockLen[T]())
+}
+
+// put returns a slice back into the pool.
+func (p *Pool[T]) put(s []T) {
+	p.p.Put(unsafe.SliceData(s))
+}

--- a/container/heap/example_intheap_test.go
+++ b/container/heap/example_intheap_test.go
@@ -1,0 +1,32 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// This example demonstrates an integer heap built using the heap interface.
+package heap_test
+
+import (
+	"fmt"
+
+	"github.com/segmentio/datastructures/v2/container/heap"
+)
+
+// Int is a min-heap entry when used in a Heap.
+type Int int
+
+func (i Int) Less(v Int) bool { return i < v }
+
+// This example inserts several ints into an IntHeap, checks the minimum,
+// and removes them in order of priority.
+func Example_IntHeap() {
+	h := &heap.Heap[Int]{2, 1, 5}
+	heap.Init(h)
+	heap.Push(h, 3)
+	fmt.Printf("minimum: %d\n", (*h)[0])
+	for h.Len() > 0 {
+		fmt.Printf("%d ", heap.Pop(h))
+	}
+	// Output:
+	// minimum: 1
+	// 1 2 3 5
+}

--- a/container/heap/example_pq_test.go
+++ b/container/heap/example_pq_test.go
@@ -1,0 +1,71 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// This example demonstrates a priority queue built using the heap interface.
+package heap_test
+
+import (
+	"fmt"
+
+	"github.com/segmentio/datastructures/v2/container/heap"
+)
+
+// An Item is something we manage in a priority queue.
+type Item struct {
+	value    string // The value of the item; arbitrary.
+	priority int    // The priority of the item in the queue.
+	// The index is needed by update and is maintained by the heap.Interface methods.
+	index int // The index of the item in the heap.
+}
+
+func (i *Item) Less(j *Item) bool {
+	// We want Pop to give us the highest, not lowest, priority so we use greater than here.
+	return i.priority > j.priority
+}
+
+func (i *Item) SetIndex(index int) {
+	i.index = index
+}
+
+// This example creates a PriorityQueue with some items, adds and manipulates an item,
+// and then removes the items in priority order.
+func Example_priorityQueue() {
+	// Some items and their priorities.
+	items := map[string]int{
+		"banana": 3, "apple": 2, "pear": 4,
+	}
+
+	// Create a priority queue, put the items in it, and
+	// establish the priority queue (heap) invariants.
+	pq := make(heap.IndexHeap[*Item], len(items))
+	i := 0
+	for value, priority := range items {
+		pq[i] = &Item{
+			value:    value,
+			priority: priority,
+			index:    i,
+		}
+		i++
+	}
+	heap.Init(&pq)
+
+	// Insert a new item and then modify its priority.
+	item := &Item{
+		value:    "orange",
+		priority: 1,
+	}
+	heap.Push(&pq, item)
+
+	// Update the priority and fix the index
+	item.priority = 5
+	heap.Fix(&pq, item.index)
+
+	// Take the items out; they arrive in decreasing priority order.
+	for pq.Len() > 0 {
+		item := heap.Pop(&pq)
+		fmt.Printf("%.2d:%s ", item.priority, item.value)
+	}
+	// Output:
+	// 05:orange 04:pear 03:banana 02:apple
+}

--- a/container/heap/heap.go
+++ b/container/heap/heap.go
@@ -1,82 +1,95 @@
+// Package heap contains the implementation of a generic heap derived from the
+// standard container/heap package. Additionally, this package provides some
+// convenince implementations that operate using go slices, simplifying the
+// interface requirements.
 package heap
 
-type Index int
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
 
-const NoIndex Index = -1
+import "sort"
 
-func (i Index) IsSet() bool {
-	return i >= 0
+// The Interface type describes the requirements
+// for a type using the routines in this package.
+// Any type that implements it may be used as a
+// min-heap with the following invariants (established after
+// [Init] has been called or if the data is empty or sorted):
+//
+//	!h.Less(j, i) for 0 <= i < h.Len() and 2*i+1 <= j <= 2*i+2 and j < h.Len()
+//
+// Note that [Push] and [Pop] in this interface are for package heap's
+// implementation to call. To add and remove things from the heap,
+// use [heap.Push] and [heap.Pop].
+type Interface[T any] interface {
+	sort.Interface
+	Push(T)
+	Pop() T
 }
 
-type Heap[T Entry[T]] []T
-
-type Entry[T any] interface {
-	Less(T) bool
-	Index() Index
-	SetIndex(i Index)
+// Init establishes the heap invariants required by the other routines in this package.
+// Init is idempotent with respect to the heap invariants
+// and may be called whenever the heap invariants may have been invalidated.
+// The complexity is O(n) where n = h.Len().
+func Init[T any, H Interface[T]](h H) {
+	n := h.Len()
+	for i := n/2 - 1; i >= 0; i-- {
+		down(h, i, n)
+	}
 }
 
-func (h Heap[T]) Len() int {
-	return len(h)
+// Push pushes the element x onto the heap.
+// The complexity is O(log n) where n = h.Len().
+func Push[T any, H Interface[T]](h H, value T) {
+	h.Push(value)
+	up(h, h.Len()-1)
 }
 
-func (h *Heap[T]) Push(value T) {
-	value.SetIndex(Index(h.Len()))
-	*h = append(*h, value)
-	h.up(h.Len() - 1)
-}
-
-func (h *Heap[T]) Pop() T {
+// Pop removes and returns the minimum element (according to Less) from the heap.
+// The complexity is O(log n) where n = h.Len().
+// Pop is equivalent to [Remove](h, 0).
+func Pop[T any, H Interface[T]](h H) T {
 	n := h.Len() - 1
-	h.swap(0, n)
-	h.down(0, n)
-	return h.pop(n)
+	h.Swap(0, n)
+	down(h, 0, n)
+	return h.Pop()
 }
 
-func (h *Heap[T]) Remove(value T) T {
-	i := int(value.Index())
+// Remove removes and returns the element at index i from the heap.
+// The complexity is O(log n) where n = h.Len().
+func Remove[T any, H Interface[T]](h H, i int) T {
 	n := h.Len() - 1
 	if n != i {
-		h.swap(i, n)
-		if !h.down(i, n) {
-			h.up(i)
+		h.Swap(i, n)
+		if !down(h, i, n) {
+			up(h, i)
 		}
 	}
-	return h.pop(n)
+	return h.Pop()
 }
 
-func (h *Heap[T]) Fix(i int) {
-	if !h.down(i, h.Len()) {
-		h.up(i)
+// Fix re-establishes the heap ordering after the element at index i has changed its value.
+// Changing the value of the element at index i and then calling Fix is equivalent to,
+// but less expensive than, calling [Remove](h, i) followed by a Push of the new value.
+// The complexity is O(log n) where n = h.Len().
+func Fix[T any, H Interface[T]](h H, i int) {
+	if !down(h, i, h.Len()) {
+		up(h, i)
 	}
 }
 
-func (h *Heap[T]) pop(n int) T {
-	old := *h
-	g := old[n]
-	*h = old[:n]
-	g.SetIndex(NoIndex)
-	return g
-}
-
-func (h Heap[T]) swap(i, j int) {
-	h[i], h[j] = h[j], h[i]
-	h[i].SetIndex(Index(i))
-	h[j].SetIndex(Index(j))
-}
-
-func (h Heap[T]) up(child int) {
+func up[T any, H Interface[T]](h H, child int) {
 	for {
 		parent := (child - 1) / 2
-		if parent == child || !h[child].Less(h[parent]) {
+		if parent == child || !h.Less(child, parent) {
 			break
 		}
-		h.swap(parent, child)
+		h.Swap(parent, child)
 		child = parent
 	}
 }
 
-func (h Heap[T]) down(parent, n int) bool {
+func down[T any, H Interface[T]](h H, parent, n int) bool {
 	start := parent
 	for {
 		left := 2*parent + 1
@@ -84,14 +97,105 @@ func (h Heap[T]) down(parent, n int) bool {
 			break
 		}
 		child := left
-		if right := left + 1; right < n && h[right].Less(h[left]) {
+		if right := left + 1; right < n && h.Less(right, left) {
 			child = right
 		}
-		if !h[child].Less(h[parent]) {
+		if !h.Less(child, parent) {
 			break
 		}
-		h.swap(parent, child)
+		h.Swap(parent, child)
 		parent = child
 	}
 	return parent > start
+}
+
+// Heap provides a convenience for implementing the [heap.Interface] as a slice
+// with entries of type T.
+type Heap[T Entry[T]] []T
+
+// Entry defines the interface requirement for each entry in a [heap.Heap].
+type Entry[T any] interface {
+	// Less reports whether the receiver is less than the passed-in value.
+	//
+	// This must hold the same transitivity of the Less method in [sort.Interface].
+	Less(T) bool
+}
+
+// Len returns the number of items in the heap. This implements the Len method
+// of [heap.Interface].
+func (h Heap[T]) Len() int { return len(h) }
+
+// Less implements [heap.Interface].
+func (h Heap[T]) Less(i, j int) bool { return h[i].Less(h[j]) }
+
+// Swap implements [heap.Interface]. This method should not be called directly.
+func (h Heap[T]) Swap(i, j int) { h[i], h[j] = h[j], h[i] }
+
+// Push implements [heap.Interface]. This method should not be called directly,
+// use [heap.Push] instead.
+func (h *Heap[T]) Push(x T) { *h = append(*h, x) }
+
+// Pop implements [heap.Interface]. This method should not be called directly,w
+// use [heap.Pop] instead.
+func (h *Heap[T]) Pop() T {
+	old := *h
+	n := len(old) - 1
+	value := old[n]
+	*h = old[:n]
+	return value
+}
+
+func pop[T any](h *[]T) T {
+	old := *h
+	n := len(old) - 1
+	value := old[n]
+	*h = old[:n]
+	return value
+}
+
+const NoIndex = -1
+
+// IndexHeap provides a convenience for implementing the [heap.Interface] as a
+// slice with entries of type T that also track the index position within each
+// entry. By storing the index, entries can easily be updated with [heap.Fix]
+// and removed using [heap.Remove].
+type IndexHeap[T IndexEntry[T]] []T
+
+// IndexEntry defines the interface requirement for each entry in a [heap.IndexHeap].
+type IndexEntry[T any] interface {
+	Entry[T]
+	// SetIndex updates the entrie's index position within the heap slice.
+	SetIndex(int)
+}
+
+// Len returns the number of items in the heap. This implements the Len method
+// of [heap.Interface].
+func (h IndexHeap[T]) Len() int { return len(h) }
+
+// Less implements [heap.Interface].
+func (h IndexHeap[T]) Less(i, j int) bool { return h[i].Less(h[j]) }
+
+// Swap implements [heap.Interface]. This method should not be called directly.
+func (h IndexHeap[T]) Swap(i, j int) {
+	h[i], h[j] = h[j], h[i]
+	h[i].SetIndex(i)
+	h[j].SetIndex(j)
+}
+
+// Push implements [heap.Interface]. This method should not be called directly,
+// use [heap.Push] instead.
+func (h *IndexHeap[T]) Push(x T) {
+	x.SetIndex(h.Len())
+	*h = append(*h, x)
+}
+
+// Pop implements [heap.Interface]. This method should not be called directly,w
+// use [heap.Pop] instead.
+func (h *IndexHeap[T]) Pop() T {
+	old := *h
+	n := len(old) - 1
+	value := old[n]
+	*h = old[:n]
+	value.SetIndex(NoIndex)
+	return value
 }

--- a/container/heap/heap.go
+++ b/container/heap/heap.go
@@ -189,7 +189,7 @@ func (h *IndexHeap[T]) Push(x T) {
 	*h = append(*h, x)
 }
 
-// Pop implements [heap.Interface]. This method should not be called directly,w
+// Pop implements [heap.Interface]. This method should not be called directly,
 // use [heap.Pop] instead.
 func (h *IndexHeap[T]) Pop() T {
 	old := *h

--- a/container/heap/heap.go
+++ b/container/heap/heap.go
@@ -164,7 +164,7 @@ type IndexHeap[T IndexEntry[T]] []T
 // IndexEntry defines the interface requirement for each entry in a [heap.IndexHeap].
 type IndexEntry[T any] interface {
 	Entry[T]
-	// SetIndex updates the entrie's index position within the heap slice.
+	// SetIndex updates the entry's index position within the heap slice.
 	SetIndex(int)
 }
 

--- a/container/heap/heap.go
+++ b/container/heap/heap.go
@@ -1,0 +1,97 @@
+package heap
+
+type Index int
+
+const NoIndex Index = -1
+
+func (i Index) IsSet() bool {
+	return i >= 0
+}
+
+type Heap[T Entry[T]] []T
+
+type Entry[T any] interface {
+	Less(T) bool
+	Index() Index
+	SetIndex(i Index)
+}
+
+func (h Heap[T]) Len() int {
+	return len(h)
+}
+
+func (h *Heap[T]) Push(value T) {
+	value.SetIndex(Index(h.Len()))
+	*h = append(*h, value)
+	h.up(h.Len() - 1)
+}
+
+func (h *Heap[T]) Pop() T {
+	n := h.Len() - 1
+	h.swap(0, n)
+	h.down(0, n)
+	return h.pop(n)
+}
+
+func (h *Heap[T]) Remove(value T) T {
+	i := int(value.Index())
+	n := h.Len() - 1
+	if n != i {
+		h.swap(i, n)
+		if !h.down(i, n) {
+			h.up(i)
+		}
+	}
+	return h.pop(n)
+}
+
+func (h *Heap[T]) Fix(i int) {
+	if !h.down(i, h.Len()) {
+		h.up(i)
+	}
+}
+
+func (h *Heap[T]) pop(n int) T {
+	old := *h
+	g := old[n]
+	*h = old[:n]
+	g.SetIndex(NoIndex)
+	return g
+}
+
+func (h Heap[T]) swap(i, j int) {
+	h[i], h[j] = h[j], h[i]
+	h[i].SetIndex(Index(i))
+	h[j].SetIndex(Index(j))
+}
+
+func (h Heap[T]) up(child int) {
+	for {
+		parent := (child - 1) / 2
+		if parent == child || !h[child].Less(h[parent]) {
+			break
+		}
+		h.swap(parent, child)
+		child = parent
+	}
+}
+
+func (h Heap[T]) down(parent, n int) bool {
+	start := parent
+	for {
+		left := 2*parent + 1
+		if left >= n || left < 0 {
+			break
+		}
+		child := left
+		if right := left + 1; right < n && h[right].Less(h[left]) {
+			child = right
+		}
+		if !h[child].Less(h[parent]) {
+			break
+		}
+		h.swap(parent, child)
+		parent = child
+	}
+	return parent > start
+}

--- a/container/heap/heap_test.go
+++ b/container/heap/heap_test.go
@@ -1,0 +1,212 @@
+package heap
+
+import (
+	"math/rand"
+	"testing"
+)
+
+type int2 int
+
+func (i int2) Less(j int2) bool { return i < j }
+
+type item struct {
+	name  string
+	value int
+	index int
+}
+
+func (i *item) Less(j *item) bool { return i.value < j.value }
+func (i *item) SetIndex(v int)    { i.index = v }
+
+func newItem(name string, value int) *item {
+	return &item{name: name, value: value, index: NoIndex}
+}
+
+func verify(t *testing.T, h Heap[int2], i int) {
+	t.Helper()
+	n := h.Len()
+	j1 := 2*i + 1
+	j2 := 2*i + 2
+	if j1 < n {
+		if h.Less(j1, i) {
+			t.Errorf("heap invariant invalidated [%d] = %d > [%d] = %d", i, h[i], j1, h[j1])
+			return
+		}
+		verify(t, h, j1)
+	}
+	if j2 < n {
+		if h.Less(j2, i) {
+			t.Errorf("heap invariant invalidated [%d] = %d > [%d] = %d", i, h[i], j1, h[j2])
+			return
+		}
+		verify(t, h, j2)
+	}
+}
+
+func TestInit0(t *testing.T) {
+	h := Heap[int2]{}
+	for i := 20; i > 0; i-- {
+		h.Push(0) // all elements are the same
+	}
+	Init(&h)
+	verify(t, h, 0)
+
+	for i := 1; h.Len() > 0; i++ {
+		x := Pop(&h)
+		verify(t, h, 0)
+		if x != 0 {
+			t.Errorf("%d.th pop got %d; want %d", i, x, 0)
+		}
+	}
+}
+
+func TestInit1(t *testing.T) {
+	h := Heap[int2]{}
+	for i := 20; i > 0; i-- {
+		h.Push(int2(i)) // all elements are different
+	}
+	Init(&h)
+	verify(t, h, 0)
+
+	for i := 1; h.Len() > 0; i++ {
+		x := Pop(&h)
+		verify(t, h, 0)
+		if int(x) != i {
+			t.Errorf("%d.th pop got %d; want %d", i, x, i)
+		}
+	}
+}
+
+func Test(t *testing.T) {
+	h := Heap[int2]{}
+	verify(t, h, 0)
+
+	for i := 20; i > 10; i-- {
+		h.Push(int2(i))
+	}
+	Init(&h)
+	verify(t, h, 0)
+
+	for i := 10; i > 0; i-- {
+		Push(&h, int2(i))
+		verify(t, h, 0)
+	}
+
+	for i := 1; h.Len() > 0; i++ {
+		x := Pop(&h)
+		if i < 20 {
+			Push(&h, int2(20+i))
+		}
+		verify(t, h, 0)
+		if int(x) != i {
+			t.Errorf("%d.th pop got %d; want %d", i, x, i)
+		}
+	}
+}
+
+func TestRemove0(t *testing.T) {
+	h := Heap[int2]{}
+	for i := 0; i < 10; i++ {
+		h.Push(int2(i))
+	}
+	verify(t, h, 0)
+
+	for h.Len() > 0 {
+		i := h.Len() - 1
+		x := Remove(&h, i)
+		if int(x) != i {
+			t.Errorf("Remove(%d) got %d; want %d", i, x, i)
+		}
+		verify(t, h, 0)
+	}
+}
+
+func TestRemove1(t *testing.T) {
+	h := Heap[int2]{}
+	for i := 0; i < 10; i++ {
+		h.Push(int2(i))
+	}
+	verify(t, h, 0)
+
+	for i := 0; h.Len() > 0; i++ {
+		x := Remove(&h, 0)
+		if int(x) != i {
+			t.Errorf("Remove(0) got %d; want %d", x, i)
+		}
+		verify(t, h, 0)
+	}
+}
+
+func TestRemove2(t *testing.T) {
+	N := 10
+
+	h := Heap[int2]{}
+	for i := 0; i < N; i++ {
+		h.Push(int2(i))
+	}
+	verify(t, h, 0)
+
+	m := make(map[int2]bool)
+	for h.Len() > 0 {
+		m[Remove(&h, (h.Len()-1)/2)] = true
+		verify(t, h, 0)
+	}
+
+	if len(m) != N {
+		t.Errorf("len(m) = %d; want %d", len(m), N)
+	}
+	for i := 0; i < len(m); i++ {
+		if !m[int2(i)] {
+			t.Errorf("m[%d] doesn't exist", i)
+		}
+	}
+}
+
+func TestFix(t *testing.T) {
+	h := Heap[int2]{}
+	verify(t, h, 0)
+
+	for i := 200; i > 0; i -= 10 {
+		Push(&h, int2(i))
+	}
+	verify(t, h, 0)
+
+	if h[0] != 10 {
+		t.Fatalf("Expected head to be 10, was %d", h[0])
+	}
+	h[0] = 210
+	Fix(&h, 0)
+	verify(t, h, 0)
+
+	for i := 100; i > 0; i-- {
+		elem := rand.Intn(h.Len())
+		if i&1 == 0 {
+			h[elem] *= 2
+		} else {
+			h[elem] /= 2
+		}
+		Fix(&h, elem)
+		verify(t, h, 0)
+	}
+}
+
+func TestIndexHeap(t *testing.T) {
+	var h IndexHeap[*item]
+	a := newItem("a", 2)
+	b := newItem("b", 1)
+	c := newItem("c", 3)
+
+	Push(&h, a)
+	Push(&h, b)
+	Push(&h, c)
+
+	for i, item := range []*item{b, a, c} {
+		if h[i].name != item.name {
+			t.Errorf("expected index %d to be %q, got %q", i, item.name, h[i].name)
+		}
+
+		if h[i].index != i {
+			t.Errorf("exected %q to have index %d, got %d", item.index, i, h[i].index)
+		}
+	}
+}

--- a/container/queue/queue.go
+++ b/container/queue/queue.go
@@ -1,0 +1,71 @@
+package queue
+
+import "github.com/segmentio/datastructures/v2/container/array"
+
+// Queue implements a FIFO queue backed by an array.Array for efficient
+// block-based allocations.
+type Queue[T any] struct {
+	values array.Array[T]
+	index  int
+}
+
+// Len gets the number of values in the queue.
+func (q *Queue[T]) Len() int {
+	return q.values.Len() - q.index
+}
+
+// Empty tests if the Queue has no entries.
+func (q *Queue[T]) Empty() bool {
+	return q.values.Len() == q.index
+}
+
+// Get obtains the value of an entry at a specific offset. Like a Go slice
+// this results in a panic if the value is outside the array bounds.
+func (q *Queue[T]) Get(i int) T {
+	return q.values.Get(i + q.index)
+}
+
+// Ptr obtains the pointer to a value for an entry at a specific offset. The
+// returned pointer is guaranteed not to change until the index is popped from
+// the array. Like a Go slice this results in a panic if the value is outside
+// the array bounds.
+func (q *Queue[T]) Ptr(i int) *T {
+	return q.values.Ptr(i + q.index)
+}
+
+// Push adds a new value to the end of the queue.
+func (q *Queue[T]) Push(v T) {
+	q.PushWithPool(v, nil)
+}
+
+// PushWithPool adds a new value to the end of the queue. If a new block is
+// required by the backing array.Array, it will be allocated from the pool.
+func (q *Queue[T]) PushWithPool(v T, pool *array.Pool[T]) {
+	q.values.PushWithPool(v, pool)
+}
+
+// Pop removes the oldest value from the queue in FIFO order if any are available.
+func (q *Queue[T]) Pop() (v T, ok bool) {
+	return q.PopWithPool(nil)
+}
+
+// PopWithPool removes the oldest value from the queue in FIFO order if any are
+// available. If the removed value was the only item remaining in the block of
+// the backing array.Array, that block will be returned to the pool.
+func (q *Queue[T]) PopWithPool(pool *array.Pool[T]) (v T, ok bool) {
+	if i, n := q.index, q.values.Len(); i < n {
+		ptr := q.values.Ptr(i)
+		v, ok, i = *ptr, true, i+1
+
+		var zero T
+		*ptr = zero // zero out as we go to avoid clear possible memory references
+
+		if i == array.BlockLen[T]() {
+			q.values.ShiftBlocksWithPool(1, pool)
+			i = 0
+		}
+
+		q.index = i
+	}
+	return
+}

--- a/container/queue/queue.go
+++ b/container/queue/queue.go
@@ -58,7 +58,7 @@ func (q *Queue[T]) PopWithPool(pool *array.Pool[T]) (v T, ok bool) {
 		v, ok, i = *ptr, true, i+1
 
 		var zero T
-		*ptr = zero // zero out as we go to avoid clear possible memory references
+		*ptr = zero // zero out as we go to avoid possible downstream memory references
 
 		if i == array.BlockLen[T]() {
 			q.values.ShiftBlocksWithPool(1, pool)

--- a/container/queue/queue.go
+++ b/container/queue/queue.go
@@ -14,7 +14,7 @@ func (q *Queue[T]) Len() int {
 	return q.values.Len() - q.index
 }
 
-// Empty tests if the Queue has no entries.
+// Empty reports whether if the queue contains no entries.
 func (q *Queue[T]) Empty() bool {
 	return q.values.Len() == q.index
 }

--- a/container/queue/queue_test.go
+++ b/container/queue/queue_test.go
@@ -53,7 +53,7 @@ func TestQueue(t *testing.T) {
 	}
 
 	if q.values.Cap() != array.BlockLen[int]() {
-		t.Errorf("capactiy should be one block: expect=%d, got=%d", array.BlockLen[int](), q.values.Cap())
+		t.Errorf("capacity should be one block: expect=%d, got=%d", array.BlockLen[int](), q.values.Cap())
 	}
 
 	for q.Len() > 0 {
@@ -64,7 +64,7 @@ func TestQueue(t *testing.T) {
 			t.Error("expected pop to remove value")
 		}
 		if v != at {
-			t.Fatalf("incorrected popped value: expect=%d, got=%d", at, v)
+			t.Fatalf("incorrect popped value: expect=%d, got=%d", at, v)
 		}
 		at += 1
 	}
@@ -74,6 +74,6 @@ func TestQueue(t *testing.T) {
 	}
 
 	if q.values.Cap() != array.BlockLen[int]() {
-		t.Errorf("capactiy should be one block: expect=%d, got=%d", array.BlockLen[int](), q.values.Cap())
+		t.Errorf("capacity should be one block: expect=%d, got=%d", array.BlockLen[int](), q.values.Cap())
 	}
 }

--- a/container/queue/queue_test.go
+++ b/container/queue/queue_test.go
@@ -1,0 +1,79 @@
+package queue
+
+import (
+	"testing"
+
+	"github.com/segmentio/datastructures/v2/container/array"
+)
+
+var pool array.Pool[int]
+
+func TestQueue(t *testing.T) {
+	var q Queue[int]
+	count := (array.BlockLen[int]() * 5) - 10
+	t.Logf("using %d entries with block size %d", count, array.BlockLen[int]())
+
+	for i := 0; i < count; i++ {
+		if q.Len() != i {
+			t.Fatalf("incorrect count: expect=%d, got=%d", i, q.Len())
+		}
+		q.PushWithPool(i+1, &pool)
+	}
+
+	if q.Len() != count {
+		t.Fatalf("incorrect count: expect=%d, got=%d", count, q.Len())
+	}
+
+	c := q.values.Cap()
+
+	v, ok := q.PopWithPool(&pool)
+	if !ok {
+		t.Fatal("expected pop to remove value")
+	}
+	if v != 1 {
+		t.Fatalf("incorrected popped value: expect=%d, got=%d", 1, v)
+	}
+	if q.Len() != count-1 {
+		t.Errorf("incorrect count: expect=%d, got=%d", count-1, q.Len())
+	}
+	if q.values.Cap() != c {
+		t.Errorf("capacity should not have changed: expect=%d, got=%d", c, q.values.Cap())
+	}
+
+	at := 2
+	for q.Len() > 10 {
+		v, ok = q.PopWithPool(&pool)
+		if !ok {
+			t.Error("expected pop to remove value")
+		}
+		if v != at {
+			t.Fatalf("incorrected popped value: expect=%d, got=%d", at, v)
+		}
+		at += 1
+	}
+
+	if q.values.Cap() != array.BlockLen[int]() {
+		t.Errorf("capactiy should be one block: expect=%d, got=%d", array.BlockLen[int](), q.values.Cap())
+	}
+
+	for q.Len() > 0 {
+		before := q.Len()
+		v, ok = q.PopWithPool(&pool)
+		t.Logf("len = %d -> %d", before, q.Len())
+		if !ok {
+			t.Error("expected pop to remove value")
+		}
+		if v != at {
+			t.Fatalf("incorrected popped value: expect=%d, got=%d", at, v)
+		}
+		at += 1
+	}
+
+	if q.Len() != 0 {
+		t.Fatalf("incorrect count: expect=%d, got=%d", 0, q.Len())
+	}
+
+	if q.values.Cap() != array.BlockLen[int]() {
+		t.Errorf("capactiy should be one block: expect=%d, got=%d", array.BlockLen[int](), q.values.Cap())
+	}
+}

--- a/container/queue/queue_test.go
+++ b/container/queue/queue_test.go
@@ -47,7 +47,7 @@ func TestQueue(t *testing.T) {
 			t.Error("expected pop to remove value")
 		}
 		if v != at {
-			t.Fatalf("incorrected popped value: expect=%d, got=%d", at, v)
+			t.Fatalf("incorrect popped value: expect=%d, got=%d", at, v)
 		}
 		at += 1
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/segmentio/datastructures/v2
 
-go 1.18
+go 1.20

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/segmentio/datastructures/v2
 
-go 1.20
+go 1.22


### PR DESCRIPTION
This adds three packages: `container/heap`, `container/array`, and `container/queue`.

The `container/heap` package is the a type-safe, generic version of the standard library `container/heap`. Additionally, there are a few convenience types for simplifying the implementation when backed by a slice.

The `container/array` package defines a growable array that uses fixed-size block allocations to minimize the computational cost of growing and shrinking the array when compared to the same operations over a slice. This also defines a type-safe, generic pool that can optionally be used for reusing block allocations.

The `container/queue` builds on top of the `container/array`, using some if it's specialized methods to implement an efficient FIFO queue.